### PR TITLE
Add endpoints.Print

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+// Endpoints is a list of Endpoints, which adds helper methods to the list.
+type Endpoints []Endpoint
+
+// Print will write the server endpoints to an io.Writer, which can be used for debugging purposes.
+// A common usage is to write to stdout (`endpoints.Print(os.Stdout)`)
+func (e Endpoints) Print(writer io.Writer) {
+	fmt.Fprint(writer, "Server endpoints:")
+	w := tabwriter.NewWriter(writer, 10, 0, 2, ' ', 0)
+	for _, endpoint := range e {
+		fmt.Fprintln(w, fmt.Sprintf("%s\t%s\t%s", endpoint.Path(), endpoint.Method(), endpoint.HandlerName()))
+	}
+	w.Flush()
+}

--- a/endpoints.go
+++ b/endpoints.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"io"
+	
 	"text/tabwriter"
 )
 


### PR DESCRIPTION
This PR adds a new `Endpoints` type, which can be used to add the helper `Print` method to print all the current server endpoints. 

Example of printing the endpoints to stdout:
```

var endpoints = api.Endpoints{
	json.NewEndpoint("GET", "/", status),
	json.NewEndpoint("GET", "/test", Test),
}

func main() {
	endpoints.Print(os.Stdout)
}
```