### PR TITLE
Adding raw endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4 (Sept 14, 2018)
+
+  * Added `Raw.Endpoint`, allowing a `http.HandlerFunc` to be used as an `Endpoint`. 
+
 ## 0.2.3 (Aug 20, 2018)
 
   * Added `Endpoints` with a helper `Print`.

--- a/raw/endpoint.go
+++ b/raw/endpoint.go
@@ -1,0 +1,53 @@
+package raw
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"runtime"
+	"time"
+)
+
+var stdNoTime = log.New(os.Stderr, "", 0)
+
+// NewEndpoint creates a raw endpoint, accepting a plain http.Handler
+func NewEndpoint(method string, path string, handler http.HandlerFunc) *Endpoint {
+	return &Endpoint{
+		method:      method,
+		path:        path,
+		handler:     handler,
+		handlerName: runtime.FuncForPC(reflect.ValueOf(handler).Pointer()).Name(),
+	}
+}
+
+type Endpoint struct {
+	method      string
+	path        string
+	handlerName string
+	handler     http.HandlerFunc
+	unlogged    bool
+}
+
+func (e Endpoint) Method() string      { return e.method }
+func (e Endpoint) Path() string        { return e.path }
+func (e Endpoint) HandlerName() string { return e.handlerName }
+func (e Endpoint) String() string {
+	return fmt.Sprintf("%s %s %s", e.method, e.path, e.handlerName)
+}
+
+func (e *Endpoint) Unlogged() *Endpoint {
+	e.unlogged = true
+	return e
+}
+
+func (e Endpoint) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		e.handler(w, r)
+		if !e.unlogged {
+			stdNoTime.Printf("%s %s %s", time.Since(start), r.RequestURI, e)
+		}
+	}
+}


### PR DESCRIPTION
The raw endpoint allows an endpoint to have access to the raw  `http.ResponseWriter` or `*http.Request`. 

This can be useful for endpoints that deal directly with the response as an `io.Writer`. 

For logging, not all the same fields can be matched as in the json endpoint, such as status code. Here's an example output:
```
1.003793ms /metrics GET /metrics github.com/BishopFox/guardian-api/metrics.Get
```