### PR TITLE
Added json.Controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,20 @@
 module github.com/BSick7/go-api
 
-go 1.13
+go 1.18
 
 require (
 	github.com/cristalhq/jwt/v3 v3.0.4
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4
-	github.com/klauspost/compress v1.13.4 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d
 	github.com/xi2/httpgzip v0.0.0-20190509075255-932ab5e254ae
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/klauspost/compress v1.13.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/json/controller.go
+++ b/json/controller.go
@@ -1,0 +1,21 @@
+package json
+
+import (
+	"net/http"
+	"time"
+)
+
+type ControllerFunc[T any] func(req *Request) (T, error)
+
+func Controller[T any](controller ControllerFunc[T]) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		res := &ResponseWriter{ResponseWriter: w, start: time.Now()}
+		req := &Request{Request: r}
+		if out, err := controller(req); err != nil {
+			res.SendError(err)
+		} else {
+			res.Send(out)
+		}
+	})
+}


### PR DESCRIPTION
This adds a `json.Controller` to provide a `return`-style interaction with APIs.

This is how an API call would differ between Controller and Handler.

#### Handler
```
// Endpoint definition
standard.NewEndpoint("GET", "/orgs/{orgName}/stacks/{stackId}/blocks/{blockId}/webhooks", json.Handler(webhooks.List)),

// API Logic
func (wh Webhooks) List(w *json.ResponseWriter, r *json.Request) {
	BlockEndpoint(w, r, func(orgName string, stackId, blockId int64) {
		webhooks, err := wh.notificationClient.GetWebhooks(orgName, stackId, blockId)
		if err != nil {
			log.Printf("unable to get webhooks: %s", err)
			w.SendError(errors.NewApiError(nil))
			return
		}

		w.Send(webhooks)
	})
}
```

#### Controller
```
// Endpoint definition
standard.NewEndpoint("GET", "/orgs/{orgName}/stacks/{stackId}/blocks/{blockId}/webhooks", json.Controller(webhooks.List)),

// API Logic
func (wh Webhooks) List(r *json.Request) ([]models.Webhook, error) {
	orgName, stackId, blockId, err := BlockEndpoint(r)
	if err != nil {
		return nil, err
	}
	return wh.notificationClient.GetWebhooks(orgName, stackId, blockId)
}
```

