### PR TITLE
Automatic errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.13.0 (Jun 21, 2023)
 * Refactor `ValidationErrors` to a slice for easier interaction.
 * Added helpers to `ValidationErrors` to swap between map and slice.
+* Added `errors.ObscureInteralErrorsMiddleware` to prevent sensitive errors from reaching users.
+  * A developer can optionally log the original error message to logs.
 
 ## 0.12.5 (Dec 16, 2022)
 

--- a/auth/authorize.go
+++ b/auth/authorize.go
@@ -12,7 +12,9 @@ type Authorizer func(r *http.Request) (*http.Request, error)
 
 // AuthorizeMiddleware creates an authorization middleware to respond based on the result of an authorization sequence
 // If using gorilla mux router, this middleware will only hit when a route is matched
-//   This is because gorilla matches a route, *then* runs the full chain of middlewares + handler
+//
+//	This is because gorilla matches a route, *then* runs the full chain of middlewares + handler
+//
 // Because of this, this makes mux.Vars(r) available to use to grab path parameters that gorilla parsed
 func AuthorizeMiddleware(authorize Authorizer) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {

--- a/errors/obscure_internal_errors.go
+++ b/errors/obscure_internal_errors.go
@@ -1,0 +1,58 @@
+package errors
+
+import (
+	"context"
+	"fmt"
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
+	"os"
+)
+
+type obscurerContextKey struct{}
+
+type Obscurer struct {
+	ObscureInternal    bool
+	LogOriginalErrorFn LogOriginalErrorFunc
+}
+
+func (c Obscurer) Obscure(err error) ApiError {
+	if !c.ObscureInternal {
+		return ApiError{Err: err}
+	}
+	if c.LogOriginalErrorFn != nil {
+		c.LogOriginalErrorFn(err)
+	}
+	return ApiError{Err: nil}
+}
+
+type LogOriginalErrorFunc func(err error)
+
+func ObscurerFromContext(ctx context.Context) Obscurer {
+	if val, ok := ctx.Value(obscurerContextKey{}).(Obscurer); ok {
+		return val
+	}
+	return Obscurer{}
+}
+
+func ContextWithObscurer(ctx context.Context, obscurer Obscurer) context.Context {
+	return context.WithValue(ctx, obscurerContextKey{}, obscurer)
+}
+
+func ObscureInternalErrorsMiddleware(logOriginal bool) mux.MiddlewareFunc {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			obscurer := Obscurer{ObscureInternal: true}
+			if logOriginal {
+				logger := log.New(os.Stderr, "", 0)
+				if requestId := r.Header.Get("X-Request-ID"); requestId != "" {
+					logger.SetPrefix(fmt.Sprintf("[%s] ", requestId))
+				}
+				obscurer.LogOriginalErrorFn = func(err error) {
+					logger.Println(err.Error())
+				}
+			}
+			handler.ServeHTTP(w, r.WithContext(ContextWithObscurer(r.Context(), obscurer)))
+		})
+	}
+}

--- a/errors/response_errorer.go
+++ b/errors/response_errorer.go
@@ -1,0 +1,5 @@
+package errors
+
+type ResponseErrorer interface {
+	ResponseError() error
+}

--- a/errors/validation_errors.go
+++ b/errors/validation_errors.go
@@ -1,8 +1,11 @@
 package errors
 
-import "fmt"
+import (
+	"fmt"
+)
 
 var _ error = ValidationError{}
+var _ ResponseErrorer = ValidationError{}
 
 type ValidationError struct {
 	Context string
@@ -13,7 +16,14 @@ func (ve ValidationError) Error() string {
 	return fmt.Sprintf("%s - %s", ve.Context, ve.Message)
 }
 
+func (ve ValidationError) ResponseError() error {
+	return InvalidRequestError{
+		Errors: ValidationErrors{ve},
+	}
+}
+
 var _ error = ValidationErrors{}
+var _ ResponseErrorer = ValidationErrors{}
 
 type ValidationErrors []ValidationError
 
@@ -51,4 +61,10 @@ func ValidationErrorsFromMap(m map[string][]string) ValidationErrors {
 		}
 	}
 	return result
+}
+
+func (ve ValidationErrors) ResponseError() error {
+	return InvalidRequestError{
+		Errors: ve,
+	}
 }

--- a/examples/app1/api/api.go
+++ b/examples/app1/api/api.go
@@ -3,6 +3,7 @@ package app1
 import (
 	"github.com/BSick7/go-api"
 	"github.com/BSick7/go-api/cors"
+	"github.com/BSick7/go-api/errors"
 	"github.com/BSick7/go-api/gzip"
 	"github.com/BSick7/go-api/intercept"
 	"github.com/BSick7/go-api/json"
@@ -26,6 +27,7 @@ func Server() *api.Server {
 	apiServer.Use(cors.Middleware(cors.DefaultSettings))
 	apiServer.Use(jwt.Middleware())
 	apiServer.Use(intercept.Middleware(false, logging.LogAllRequests("[app1] ")))
+	apiServer.Use(errors.ObscureInternalErrorsMiddleware(true))
 	apiServer.Register(endpoints...)
 	apiServer.Register(cors.Preflight())
 	return apiServer

--- a/examples/app1/api/simple_test.go
+++ b/examples/app1/api/simple_test.go
@@ -16,9 +16,10 @@ func TestSimple(t *testing.T) {
 			Want:    json.ExpectBadRequest([]string{"missing data"}),
 		},
 		{
+			// NOTE: This is a generic error message so it's obscured by API middleware
 			Name:    "invalid-input",
 			Request: httptest.NewRequest("GET", "/simple?data=hey", nil),
-			Want:    json.ExpectInternalError(fmt.Errorf("invalid syntax")),
+			Want:    json.ExpectInternalError(fmt.Errorf("We have encountered an unexpected error.")),
 		},
 		{
 			Name:    "success",

--- a/json/handler.go
+++ b/json/handler.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"github.com/BSick7/go-api/errors"
 	"net/http"
 	"time"
 )
@@ -10,7 +11,11 @@ type HandlerFunc func(res *ResponseWriter, req *Request)
 func Handler(handler HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		res := &ResponseWriter{ResponseWriter: w, start: time.Now()}
+		res := &ResponseWriter{
+			ResponseWriter: w,
+			start:          time.Now(),
+			Obscurer:       errors.ObscurerFromContext(r.Context()),
+		}
 		req := &Request{Request: r}
 		handler(res, req)
 	})

--- a/json/response_error.go
+++ b/json/response_error.go
@@ -1,9 +1,0 @@
-package json
-
-type StatusCoder interface {
-	StatusCode() int
-}
-
-type ResponsePayloader interface {
-	Payload() map[string]interface{}
-}

--- a/json/response_writer.go
+++ b/json/response_writer.go
@@ -54,11 +54,12 @@ func (w *ResponseWriter) SendError(err error) {
 	// The interfaces defined in the errors package are not specific to json serialization
 	// This ResponsePayloader allows us to structure content before emitting in the json format
 	// Additionally, errors that aren't a ResponsePayloader are obscured (configurable through middleware)
-	encoder := json.NewEncoder(w.ResponseWriter)
 	payloader, ok := err.(ResponsePayloader)
 	if !ok {
 		payloader = w.Obscurer.Obscure(err)
 	}
+
+	encoder := json.NewEncoder(w.ResponseWriter)
 	if err := encoder.Encode(payloader.Payload()); err != nil {
 		fmt.Printf("[go-api/json/response_writer] Error encoding error payload: %s\n", err)
 	}

--- a/jsonapi/handler.go
+++ b/jsonapi/handler.go
@@ -1,10 +1,10 @@
 package jsonapi
 
 import (
+	"github.com/BSick7/go-api/errors"
+	"github.com/svanharmelen/jsonapi"
 	"net/http"
 	"time"
-
-	"github.com/svanharmelen/jsonapi"
 )
 
 type HandlerFunc func(res *ResponseWriter, req *Request)
@@ -12,7 +12,11 @@ type HandlerFunc func(res *ResponseWriter, req *Request)
 func Handler(handler HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", jsonapi.MediaType)
-		res := &ResponseWriter{ResponseWriter: w, start: time.Now()}
+		res := &ResponseWriter{
+			ResponseWriter: w,
+			start:          time.Now(),
+			Obscurer:       errors.ObscurerFromContext(r.Context()),
+		}
 		req := &Request{Request: r}
 		handler(res, req)
 	})

--- a/jsonapi/response_writer.go
+++ b/jsonapi/response_writer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	api_errors "github.com/BSick7/go-api/errors"
 	"log"
 	"net"
 	"net/http"
@@ -78,6 +79,10 @@ func (w *ResponseWriter) SendError(err error) {
 		if isc, ok := err.(StatusCoder); ok {
 			jaerr.Code = strconv.Itoa(isc.StatusCode())
 			jaerr.Status = http.StatusText(isc.StatusCode())
+		}
+		var rerr api_errors.ResponseErrorer
+		if errors.As(err, &rerr) {
+			err = rerr.ResponseError()
 		}
 		if payloader, ok := err.(ResponsePayloader); ok {
 			payload := payloader.Payload()


### PR DESCRIPTION
This improves the ergonomics of reporting `ValidationErrors` and `ValidationError`.
This also adds middleware to obscure internal errors from the response. (Optionally, the original error can be logged)
This was applied to the `json` and `jsonapi` packages.

Before:
```
if err != nil {
	var ves errors.ValidationErrors
	if errors3.As(err, &ves) {
		w.SendError(errors.InvalidRequestError{
			Errors: ves,
		})
		return
	}
	var ve errors.ValidationError
	if errors3.As(err, &ve) {
		w.SendError(errors.InvalidRequestError{
			Errors: errors.ValidationErrors{ve},
		})
		return
	}
	w.SendError(errors.NewApiError(nil))
	return
}
```

After:
```
apiServer.Use(errors.ObscureInternalErrorsMiddleware(true))
...
if err != nil {
	w.SendError(err)
	return
}
```