### PR TITLE
Middleware chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.1 (Mar 01, 2024)
+* Added `MiddlewareChain` to create a set of middlewares without using a router. This is helpful to apply middleware to a single HTTP handler.
+
 # 0.14.0 (Jan 24, 2024)
 * Added `ErrorCode` to `ApiError` to emit application-specific error codes.
 * Changed `BadRequestError.Details` from `[]string` to `map[string]string`

--- a/middlewares.go
+++ b/middlewares.go
@@ -1,0 +1,31 @@
+package api
+
+import "net/http"
+
+type MiddlewareFunc func(http.Handler) http.Handler
+
+func (mw MiddlewareFunc) Middleware(handler http.Handler) http.Handler {
+	return mw(handler)
+}
+
+type Middleware interface {
+	Middleware(handler http.Handler) http.Handler
+}
+
+type MiddlewareChain struct {
+	Middlewares []Middleware
+}
+
+func (c *MiddlewareChain) Use(mwf ...MiddlewareFunc) {
+	for _, fn := range mwf {
+		c.Middlewares = append(c.Middlewares, fn)
+	}
+}
+
+func (c *MiddlewareChain) Apply(handler http.Handler) http.Handler {
+	cur := handler
+	for i := len(c.Middlewares) - 1; i >= 0; i-- {
+		cur = c.Middlewares[i].Middleware(cur)
+	}
+	return cur
+}

--- a/middlewares.go
+++ b/middlewares.go
@@ -19,6 +19,9 @@ func (c *MiddlewareChain) Use(mwf ...mux.MiddlewareFunc) {
 	}
 }
 
+// Apply takes an input http.Handler and applies the middleware chain over a single http.Handler
+// These middlewares are chained in the order they are registered
+// If middleware A is registered earlier than B, then execution will be A => B => handler
 func (c *MiddlewareChain) Apply(handler http.Handler) http.Handler {
 	cur := handler
 	for i := len(c.Middlewares) - 1; i >= 0; i-- {

--- a/middlewares.go
+++ b/middlewares.go
@@ -1,12 +1,9 @@
 package api
 
-import "net/http"
-
-type MiddlewareFunc func(http.Handler) http.Handler
-
-func (mw MiddlewareFunc) Middleware(handler http.Handler) http.Handler {
-	return mw(handler)
-}
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+)
 
 type Middleware interface {
 	Middleware(handler http.Handler) http.Handler
@@ -16,7 +13,7 @@ type MiddlewareChain struct {
 	Middlewares []Middleware
 }
 
-func (c *MiddlewareChain) Use(mwf ...MiddlewareFunc) {
+func (c *MiddlewareChain) Use(mwf ...mux.MiddlewareFunc) {
 	for _, fn := range mwf {
 		c.Middlewares = append(c.Middlewares, fn)
 	}


### PR DESCRIPTION
This adds `MiddlewareChain` which acts serves the same purpose of `mux.Router` middlewares; however, this chain can be applied to a single http.Handler without taking on the weight of an entire `mux.Router`.