### PR TITLE
Use httpsnoop for intercept Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.15.0 (Mar 04, 2024)
+* Reimplemented `intercept.Middleware` to use [`httpsnoop`](https://github.com/felixge/httpsnoop).
+
 # 0.14.1 (Mar 01, 2024)
 * Added `MiddlewareChain` to create a set of middlewares without using a router. This is helpful to apply middleware to a single HTTP handler.
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/cristalhq/jwt/v3 v3.0.4
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cristalhq/jwt/v3 v3.0.4 h1:1x04GZr04SJ3vd1Fsbl9eCPAuLwl753P7ywWgISrnd
 github.com/cristalhq/jwt/v3 v3.0.4/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/intercept/middleware.go
+++ b/intercept/middleware.go
@@ -1,78 +1,34 @@
 package intercept
 
 import (
-	"bufio"
-	"fmt"
-	"net"
-	"net/http"
-	"strings"
-	"time"
-
+	"github.com/felixge/httpsnoop"
 	"github.com/gorilla/mux"
+	"net/http"
+	"time"
 )
 
-type ResponseData interface {
-	StatusCode() int
-	Body() string
+type ResponseData struct {
+	// StatusCode represents the response's status code
+	StatusCode int
+	// Duration is the total duration of the request/response
+	Duration time.Duration
+	// Written is the number of bytes written in the response
+	Written int64
 }
 
-type OnResponseFunc func(r *http.Request, data ResponseData, duration time.Duration)
+type OnResponseFunc func(r *http.Request, data ResponseData)
 
-func Middleware(captureBody bool, onResponses ...OnResponseFunc) mux.MiddlewareFunc {
+func Middleware(onResponses ...OnResponseFunc) mux.MiddlewareFunc {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			start := time.Now()
-			wrapped := &responseWriterInterceptor{ResponseWriter: w, captureBody: captureBody, statusCode: http.StatusOK}
-			handler.ServeHTTP(wrapped, r)
+			m := httpsnoop.CaptureMetrics(handler, w, r)
 			for _, onResponse := range onResponses {
-				onResponse(r, wrapped, time.Since(start))
+				onResponse(r, ResponseData{
+					StatusCode: m.Code,
+					Duration:   m.Duration,
+					Written:    m.Written,
+				})
 			}
 		})
 	}
-}
-
-var _ ResponseData = &responseWriterInterceptor{}
-var _ http.Hijacker = &responseWriterInterceptor{}
-
-type responseWriterInterceptor struct {
-	http.ResponseWriter
-	captureBody  bool
-	statusCode   int
-	capturedData []string
-}
-
-func (w *responseWriterInterceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
-		return hijacker.Hijack()
-	}
-	return nil, nil, fmt.Errorf("can't switch protocols using non-Hijacker ResponseWriter type %T", w.ResponseWriter)
-}
-
-func (w *responseWriterInterceptor) StatusCode() int {
-	return w.statusCode
-}
-
-func (w *responseWriterInterceptor) Body() string {
-	if w.captureBody {
-		return strings.Join(w.capturedData, "")
-	}
-	return ""
-}
-
-func (w *responseWriterInterceptor) Header() http.Header {
-	return w.ResponseWriter.Header()
-}
-
-func (w *responseWriterInterceptor) Write(data []byte) (int, error) {
-	if w.captureBody {
-		if w.statusCode >= 400 {
-			w.capturedData = append(w.capturedData, string(data))
-		}
-	}
-	return w.ResponseWriter.Write(data)
-}
-
-func (w *responseWriterInterceptor) WriteHeader(statusCode int) {
-	w.statusCode = statusCode
-	w.ResponseWriter.WriteHeader(statusCode)
 }

--- a/logging/all.go
+++ b/logging/all.go
@@ -1,18 +1,16 @@
 package logging
 
 import (
+	"github.com/BSick7/go-api/intercept"
 	"log"
 	"net/http"
 	"os"
-	"time"
-
-	"github.com/BSick7/go-api/intercept"
 )
 
 func LogAllRequests(prefix string) intercept.OnResponseFunc {
 	stdNoTime := log.New(os.Stderr, prefix, 0)
 
-	return func(r *http.Request, data intercept.ResponseData, duration time.Duration) {
-		stdNoTime.Printf("%s %d %s %s %s", duration, data.StatusCode(), r.Method, r.RequestURI, data.Body())
+	return func(r *http.Request, data intercept.ResponseData) {
+		stdNoTime.Printf("%s %d %s %s", data.Duration, data.StatusCode, r.Method, r.RequestURI)
 	}
 }


### PR DESCRIPTION
httpsnoop is a more robust wrapper for capturing status code and duration of HTTP handlers.