### PR TITLE
Next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.16.1 (Mar 07, 2024)
+* Added `errors.CaptureMiddleware` to report API errors.
+* Added macros to `errors` for creating path/querystring/payload parse errors.
+
 # 0.16.0 (Mar 06, 2024)
 * Improved `recovery.PanicMiddleware` to inject `PanicError` (adheres to `error`) instead of `interface{}`.
 * `PanicError` contains stack trace as `StackTrace() []byte`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.16.1 (Mar 07, 2024)
 * Added `errors.CaptureMiddleware` to report API errors.
 * Added macros to `errors` for creating path/querystring/payload parse errors.
+* Added request parsers that automate parsing and error wrapping.
 
 # 0.16.0 (Mar 06, 2024)
 * Improved `recovery.PanicMiddleware` to inject `PanicError` (adheres to `error`) instead of `interface{}`.

--- a/errors/capture.go
+++ b/errors/capture.go
@@ -1,0 +1,45 @@
+package errors
+
+import (
+	"context"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+// CaptureFunc is injected in the middleware
+// This function is used to react to API erros
+type CaptureFunc func(r *http.Request, statusCode int, err error)
+
+// OnCaptureFunc is used by producers of errors to signal an error
+// This is used as a wrapper in the capture middleware to forward the http.Request into the CaptureFunc
+// This is necessary because the producer (i.e. ResponseWriter) doesn't have access to the http.Request
+type OnCaptureFunc func(statusCode int, err error)
+
+type captureContextKey struct{}
+
+func CapturerFromContext(ctx context.Context) OnCaptureFunc {
+	if fn, ok := ctx.Value(captureContextKey{}).(OnCaptureFunc); ok {
+		return fn
+	}
+	return func(statusCode int, err error) {}
+}
+
+func ContextWithCapturer(ctx context.Context, capturer OnCaptureFunc) context.Context {
+	if capturer == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, captureContextKey{}, capturer)
+}
+
+// CaptureMiddleware enables the API server to capture the body of error responses
+// These errors can be used to perform any action like reporting an error to a telemetry provider.
+func CaptureMiddleware(capturer CaptureFunc) mux.MiddlewareFunc {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			newCtx := ContextWithCapturer(r.Context(), func(statusCode int, err error) {
+				capturer(r, statusCode, err)
+			})
+			handler.ServeHTTP(w, r.WithContext(newCtx))
+		})
+	}
+}

--- a/errors/parse_errors.go
+++ b/errors/parse_errors.go
@@ -1,0 +1,42 @@
+package errors
+
+import (
+	"fmt"
+)
+
+const (
+	ErrorCodeInvalidPathParameter  = 10000
+	ErrorCodeInvalidQueryParameter = 10001
+	ErrorCodeInvalidPayload        = 10002
+)
+
+func InvalidPathParameter(part string, message string) BadRequestError {
+	details := map[string]string{
+		"parameter": part,
+		"message":   message,
+	}
+	return NewBadRequestError(ErrorCodeInvalidPathParameter, details)
+}
+
+func InvalidQueryParameter(field string, message string) BadRequestError {
+	details := map[string]string{
+		"parameter": field,
+		"message":   message,
+	}
+	return NewBadRequestError(ErrorCodeInvalidQueryParameter, details)
+}
+
+func InvalidPayload(err error) BadRequestError {
+	details := map[string]string{
+		"message": fmt.Sprintf("invalid payload: %s", err),
+	}
+	return NewBadRequestError(ErrorCodeInvalidPayload, details)
+}
+
+func InvalidPayloadAttribute(attribute string, message string) BadRequestError {
+	details := map[string]string{
+		"attribute": attribute,
+		"message":   message,
+	}
+	return NewBadRequestError(ErrorCodeInvalidPayload, details)
+}

--- a/errors/parse_errors.go
+++ b/errors/parse_errors.go
@@ -8,6 +8,7 @@ const (
 	ErrorCodeInvalidPathParameter  = 10000
 	ErrorCodeInvalidQueryParameter = 10001
 	ErrorCodeInvalidPayload        = 10002
+	ErrorCodeRequiredField         = 10003
 )
 
 func InvalidPathParameter(part string, message string) BadRequestError {
@@ -31,6 +32,20 @@ func InvalidPayload(err error) BadRequestError {
 		"message": fmt.Sprintf("invalid payload: %s", err),
 	}
 	return NewBadRequestError(ErrorCodeInvalidPayload, details)
+}
+
+func RequiredPathParameter(part string) BadRequestError {
+	details := map[string]string{
+		"message": fmt.Sprintf("%s is required", part),
+	}
+	return NewBadRequestError(ErrorCodeRequiredField, details)
+}
+
+func RequiredPayloadField(field string) BadRequestError {
+	details := map[string]string{
+		"message": fmt.Sprintf("%s is required", field),
+	}
+	return NewBadRequestError(ErrorCodeRequiredField, details)
 }
 
 func InvalidPayloadAttribute(attribute string, message string) BadRequestError {

--- a/examples/app1/api/api.go
+++ b/examples/app1/api/api.go
@@ -28,6 +28,9 @@ func Server() *api.Server {
 	apiServer.Use(gzip.Middleware())
 	apiServer.Use(recovery.PanicMiddleware())
 	apiServer.Use(cors.Middleware(cors.DefaultSettings))
+	apiServer.Use(errors.CaptureMiddleware(func(r *http.Request, statusCode int, err error) {
+		log.Printf("captured api error [code = %d, err = %s]\n", statusCode, err)
+	}))
 	apiServer.Use(ga_jwt.ClaimsMiddleware[jwt.StandardClaims](handleJwtError))
 	apiServer.Use(intercept.Middleware(logging.LogAllRequests("[app1] ")))
 	apiServer.Use(errors.ObscureInternalErrorsMiddleware(true))

--- a/json/handler.go
+++ b/json/handler.go
@@ -15,6 +15,7 @@ func Handler(handler HandlerFunc) http.Handler {
 			ResponseWriter: w,
 			start:          time.Now(),
 			Obscurer:       errors.ObscurerFromContext(r.Context()),
+			ErrorCapturer:  errors.CapturerFromContext(r.Context()),
 		}
 		req := &Request{Request: r}
 		handler(res, req)

--- a/json/response_writer.go
+++ b/json/response_writer.go
@@ -23,9 +23,10 @@ var _ http.Hijacker = &ResponseWriter{}
 
 type ResponseWriter struct {
 	http.ResponseWriter
-	Obscurer   api_errors.Obscurer
-	start      time.Time
-	statusCode int
+	Obscurer      api_errors.Obscurer
+	ErrorCapturer api_errors.OnCaptureFunc
+	start         time.Time
+	statusCode    int
 }
 
 func (w *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
@@ -63,6 +64,7 @@ func (w *ResponseWriter) SendError(err error) {
 	if err := encoder.Encode(payloader.Payload()); err != nil {
 		fmt.Printf("[go-api/json/response_writer] Error encoding error payload: %s\n", err)
 	}
+	w.ErrorCapturer(w.statusCode, err)
 }
 
 func (w *ResponseWriter) Send(data interface{}) {

--- a/jsonapi/handler.go
+++ b/jsonapi/handler.go
@@ -16,6 +16,7 @@ func Handler(handler HandlerFunc) http.Handler {
 			ResponseWriter: w,
 			start:          time.Now(),
 			Obscurer:       errors.ObscurerFromContext(r.Context()),
+			ErrorCapturer:  errors.CapturerFromContext(r.Context()),
 		}
 		req := &Request{Request: r}
 		handler(res, req)

--- a/request/parsers.go
+++ b/request/parsers.go
@@ -1,0 +1,52 @@
+package request
+
+import (
+	"fmt"
+	"github.com/BSick7/go-api/errors"
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func Int64PathParameter(r *http.Request, name string) (int64, error) {
+	vars := mux.Vars(r)
+	val, err := strconv.ParseInt(vars[name], 10, 64)
+	if err != nil {
+		log.Printf("%s is not a valid int64: %s\n", name, err)
+		return 0, errors.InvalidPathParameter(name, fmt.Sprintf("%s must be an integer", name))
+	}
+	return val, nil
+}
+
+func Int64QueryParam(r *http.Request, name string) (int64, error) {
+	q := r.URL.Query()
+	val, err := strconv.ParseInt(q.Get(name), 10, 64)
+	if err != nil {
+		log.Printf("%s is not a valid int64: %s\n", name, err)
+		return 0, errors.InvalidQueryParameter(name, fmt.Sprintf("%s must be an integer", name))
+	}
+	return val, nil
+}
+
+func StringSliceQueryParam(r *http.Request, name string) []string {
+	q := r.URL.Query()
+	if val := q.Get(name); val != "" {
+		return strings.Split(val, ",")
+	}
+	return nil
+}
+
+func OptionalTimeQueryParam(r *http.Request, name string) (*time.Time, error) {
+	q := r.URL.Query()
+	if val := q.Get(name); val != "" {
+		if rawEnd, err := time.Parse(time.RFC3339, val); err != nil {
+			return nil, errors.InvalidQueryParameter(name, err.Error())
+		} else {
+			return &rawEnd, nil
+		}
+	}
+	return nil, nil
+}

--- a/request/parsers.go
+++ b/request/parsers.go
@@ -3,6 +3,7 @@ package request
 import (
 	"fmt"
 	"github.com/BSick7/go-api/errors"
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"log"
 	"net/http"
@@ -10,6 +11,16 @@ import (
 	"strings"
 	"time"
 )
+
+func UuidPathParameter(r *http.Request, name string) (uuid.UUID, error) {
+	vars := mux.Vars(r)
+	val, err := uuid.Parse(vars[name])
+	if err != nil {
+		log.Printf("%s is not a valid uuid: %s\n", name, err)
+		return uuid.Nil, errors.InvalidPathParameter(name, fmt.Sprintf("%s must be a uuid", name))
+	}
+	return val, nil
+}
 
 func Int64PathParameter(r *http.Request, name string) (int64, error) {
 	vars := mux.Vars(r)


### PR DESCRIPTION
* Added `errors.CaptureMiddleware` to report API errors.
* Added macros to `errors` for creating path/querystring/payload parse errors.
* Added request parsers that automate parsing and error wrapping.